### PR TITLE
Allow external TypeScript projects to reference

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,7 +20,8 @@
     "paths": {
       "*" : ["src/@customTypes/*"]
     },
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    "composite": true
   },
   "exclude": [
     "dist",


### PR DESCRIPTION
Allow external TypeScript projects to reference the library directly. 